### PR TITLE
Some nginx related changes.

### DIFF
--- a/docs/assets/nginx.conf
+++ b/docs/assets/nginx.conf
@@ -3,23 +3,16 @@ pid /var/run/nginx.pid;
 
 
 worker_processes auto;
-worker_rlimit_nofile 300000; # needs to be < ulimit -n
+worker_cpu_affinity auto;
+worker_rlimit_nofile 80100; # ensures that OS limit is correct. Every client may use up to 3. + something for logs
 
 error_log /data/nginx/logs/nginx-error.log warn;
 
 events {
-    worker_connections 40000;
-    multi_accept off; # very important, otherwise one worker might get all the connections
+    worker_connections 40000; # 1 per client, 1 per upstream
 }
 
 http {
-    # aggressive caching for read-only sources
-    open_file_cache max=1000000 inactive=60m;
-    open_file_cache_valid 60m;
-    open_file_cache_min_uses 1;
-    open_file_cache_errors on;
-
-    server_tokens off;
 
     include /etc/nginx/mime.types;
     types {
@@ -29,16 +22,16 @@ http {
 
     charset utf-8;
 
-    sendfile on;
+    sendfile on; # effectively disabled by ssl, gzip or any other CPU related tasks 
     tcp_nopush on;
     tcp_nodelay on;
 
     reset_timedout_connection on;
-    send_timeout 20;
+    send_timeout 2; # timeout between write()'s. Behind a CDN even 1s is a rather high timeout.
 
     max_ranges 0;
 
-    gzip on;
+    gzip on; # effectively disables sendfile
     gzip_comp_level 1;
     gzip_types application/json application/x-protobuf;
 
@@ -225,20 +218,18 @@ map "" $empty {
 }
 
 server {
-    listen 80 default_server;
-    listen [::]:80 default_server;
+    listen 80 reuseport default_server;
+    listen [::]:80 reuseport default_server;
 
-    listen 443 ssl default_server;
-    listen [::]:443 ssl default_server;
+    listen 443 ssl reuseport default_server;
+    listen [::]:443 ssl reuseport default_server;
     http2 on;
 
     server_name _;
 
-    ssl_ciphers aNULL;
-    ssl_certificate /etc/nginx/ssl/dummy.crt;
-    ssl_certificate_key /etc/nginx/ssl/dummy.key;
+    ssl_reject_handshake on;
 
-    return 444;
+    return 204;
 }
 
 # configuration file /data/nginx/sites/ofm_roundrobin.conf:
@@ -247,10 +238,13 @@ server {
 
     # ssl: https://ssl-config.mozilla.org / intermediate config
 
-    listen 80;
-    listen 443 ssl;
-    listen [::]:443 ssl;
+    listen 80 reuseport ;
+    listen 443 ssl reuseport ;
+    listen [::]:443 ssl reuseport ;
     http2 on;
+
+    keepalive_time 1h; # default is 1h, if there is CDN in front of the server - increase the time a connection lives
+    keepalive_requests 100000; # default is 1000, which is rather low
 
     ssl_certificate /data/nginx/certs/ofm_roundrobin.cert;
     ssl_certificate_key /data/nginx/certs/ofm_roundrobin.key;
@@ -264,7 +258,7 @@ server {
     # intermediate configuration
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
-    ssl_prefer_server_ciphers off;
+    #ssl_prefer_server_ciphers off; # default is "off"
 
     # access log doesn't contain IP address
     access_log off;

--- a/ssh_lib/assets/nginx/default_disable.conf
+++ b/ssh_lib/assets/nginx/default_disable.conf
@@ -3,18 +3,15 @@ map "" $empty {
 }
 
 server {
-    listen 80 default_server;
-    listen [::]:80 default_server;
+    listen 80 reuseport default_server;
+    listen [::]:80 reuseport default_server;
 
-    listen 443 ssl default_server;
-    listen [::]:443 ssl default_server;
+    listen 443 ssl reuseport default_server;
+    listen [::]:443 ssl reuseport default_server;
     http2 on;
 
     server_name _;
 
-    ssl_ciphers aNULL;
-    ssl_certificate /etc/nginx/ssl/dummy.cert;
-    ssl_certificate_key /etc/nginx/ssl/dummy.key;
-
-    return 444;
+    ssl_reject_handshake on;
+    return 204;
 }

--- a/ssh_lib/assets/nginx/nginx.conf
+++ b/ssh_lib/assets/nginx/nginx.conf
@@ -5,22 +5,16 @@ pid /var/run/nginx.pid;
 # universal
 
 worker_processes auto;
-worker_rlimit_nofile 300000; # needs to be < ulimit -n
+worker_cpu_affinity auto;
+worker_rlimit_nofile 80100; # ensures that OS limits are correct
 
 error_log /data/nginx/logs/nginx-error.log warn;
 
 events {
     worker_connections 40000;
-    multi_accept off; # very important, otherwise one worker might get all the connections
 }
 
 http {
-    # aggressive caching for read-only sources
-    open_file_cache max=1000000 inactive=60m;
-    open_file_cache_valid 60m;
-    open_file_cache_min_uses 1;
-    open_file_cache_errors on;
-
     server_tokens off;
 
     include /etc/nginx/mime.types;


### PR DESCRIPTION
Hello,

I saw you post at nginx community forum and decided to get involved:)

open file cache is mostly used to battle VFS locks. Those will matter if you have a lot of open()'s along with reads and writes (usually happen with proxy_pass + temp files + closer to 1kk rps). And these were mostly solved in linux kernel since open file cache was introduced into nginx.

reuseport may cause some security "issues". As in "any application can listen to the same port as nginx and have its traffic". Not a great concern in most cases. But it ensures better (though still not ideal) load distribution across workers

If your nginx instance has a CDN in front of it - keepalive timeouts should be increased significantly. Otherwise you are reopening connections every 1000 requests (which may happen within milliseconds)

multi accept works well in synthetic tests and can easily fail you in real life.

rlimit nofile is used to make nginx get set the limit on open files properly (basically - test that OS limits are correct). If you have 1 client connection it may open 1 upstream connection and 1 file (cache or proxy temp). Both client and upstream connections are accounted into worker connections. So if you have a limit of 20k connections it gives you 10k clients with proxy, 20k clients without proxy, up to 30k open files when there is proxy, up to 40k files without proxy.

Sendfile only works if there is no postprocessing in the application. SSL, gzip, any other filters require application logic that effectively disables sendfile.

gzip on along with gzip level 1 is a wise choice though :) But if files are pregzipped - it can probably be disabled. Check out https://nginx.org/en/docs/http/ngx_http_gzip_static_module.html . Not sure how applicable to you this is.

I would also get rid of RE locations. Or try to hide them inside appropriate prefix locations. But this requires careful testing before implementation.

I didn't test the config but I'm happy to answer any questions you may have.

Cheers!