### PR TITLE
Implement dark mode styles for website

### DIFF
--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -133,3 +133,36 @@ hr {
     }
   }
 }
+
+@media (prefers-color-scheme:dark) {
+  :root {
+    color-scheme:dark;
+  }
+
+  body {
+    color: #FFF;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: #CCC;
+  }
+
+  #style-url-pre {
+    background: #101010;
+  }
+
+  p {
+    a {
+      color: #CCC;
+    }
+  }
+  
+  strong {
+    color: #CCC;
+  }
+}


### PR DESCRIPTION
Screenshot shows page rendered with OS light and dark mode enabled

<img width="1882" height="4448" alt="Screenshot of homepage rendered with OS light mode (left side) and dark mode (right side)" src="https://github.com/user-attachments/assets/7224bbf0-fdae-4d42-bd71-a663a9a4307e" />
