### PR TITLE
Update pkg_base.py

### DIFF
--- a/ssh_lib/pkg_base.py
+++ b/ssh_lib/pkg_base.py
@@ -38,7 +38,7 @@ def pkg_base(c):
         'autojump',
         'bash-completion',
         'btop',
-        'ctop',
+        #'ctop',
         'dbus',
         'direnv',
         'fd-find',


### PR DESCRIPTION
ctop no longer available in Ubuntu